### PR TITLE
Fixes #687: Purging message cookies fails when cookies that can not be decrypted exist

### DIFF
--- a/source/Core/Configuration/Hosting/MessageCookie.cs
+++ b/source/Core/Configuration/Hosting/MessageCookie.cs
@@ -19,6 +19,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using Thinktecture.IdentityModel;
 using Thinktecture.IdentityServer.Core.Extensions;
 using Thinktecture.IdentityServer.Core.Logging;
@@ -198,22 +199,39 @@ namespace Thinktecture.IdentityServer.Core.Configuration.Hosting
                 });
         }
 
+        private long GetCookieRank(string name)
+        {   // empty and invalid cookies are considered to be the oldest:
+            var rank = DateTime.MinValue.Ticks;
+            try
+            {
+                var m = ReadByCookieName(name);
+                if (m != null)
+                {   // valid cookies are ranked based on their creation time:
+                    rank = m.Requested;
+                }
+            }
+            catch (CryptographicException e)
+            {   // cookie was protected with a different key/algorithm
+                Logger.DebugFormat("Unable to decrypt cookie {0}: {1}", name, e.Message);
+            }
+            return rank;
+        }
+
         private void ClearOverflow()
         {
             var names = GetCookieNames();
             if (names.Count() > Constants.SignInMessageThreshold)
             {
-                var messages =
+                var rankedCookieNames =
                     from name in names
-                    let m = ReadByCookieName(name)
-                    where m != null
-                    orderby m.Requested descending
-                    select new { name = name, message = m };
+                    let rank = GetCookieRank(name)
+                    orderby rank descending
+                    select name;
 
-                var purge = messages.Skip(Constants.SignInMessageThreshold);
-                foreach (var item in purge)
+                var purge = rankedCookieNames.Skip(Constants.SignInMessageThreshold);
+                foreach (var name in purge)
                 {
-                    ClearByCookieName(item.name);
+                    ClearByCookieName(name);
                 }
             }
         }


### PR DESCRIPTION
Please see #687 for details.

There are no tests. Let me know if this is not acceptable.
I've signed the [Contributor License Agreement](https://cla.dotnetfoundation.org/), should be in your inbox.

Cheers, and thanks for your work!



<!---
@huboard:{"order":568.43359375,"milestone_order":686.0,"custom_state":""}
-->
