### PR TITLE
Added empty ctor to ClientSecret for serialization use

### DIFF
--- a/source/Core/Models/ClientSecret.cs
+++ b/source/Core/Models/ClientSecret.cs
@@ -50,6 +50,13 @@ namespace Thinktecture.IdentityServer.Core.Models
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientSecret"/> class.
         /// </summary>
+        public ClientSecret()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientSecret"/> class.
+        /// </summary>
         /// <param name="value">The value.</param>
         /// <param name="expiration">The expiration.</param>
         public ClientSecret(string value, DateTimeOffset? expiration = null)


### PR DESCRIPTION
For implementors of IAuthorizationCodeStore wanting to persist the AuthorizationCode serialized, ClientSecret needs an empty ctor for it to be deserialized.

This is due to AuthorizationCode having a Client property, which again has a ClientSecret property.

