### PR TITLE
Update FormPostResponse.js

### DIFF
--- a/source/Core/Services/DefaultViewService/HttpAssets/app/FormPostResponse.js
+++ b/source/Core/Services/DefaultViewService/HttpAssets/app/FormPostResponse.js
@@ -4,5 +4,5 @@
  */
 
 (function () {
-    document.querySelector("form").submit();
+    document.forms[0].submit();
 })();


### PR DESCRIPTION
Remove `querySelector` and use more widely supported method of submitting the form.

Fixes #779